### PR TITLE
we consider remoterequirement consistent if remote is not accessible …

### DIFF
--- a/pluto/src/build/pluto/dependency/RemoteRequirement.java
+++ b/pluto/src/build/pluto/dependency/RemoteRequirement.java
@@ -45,6 +45,13 @@ public abstract class RemoteRequirement implements Requirement {
         long timestamp = getStartingTimestamp();
         if(needsConsistencyCheck(timestamp)) {
             Log.log.log("Check if the remote resource is consistent with the local resource", Log.CORE);
+            if (!isRemoteResourceAccessible()) {
+                if (isLocalResourceAvailable()) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
             if(isConsistentWithRemote()){
                 writePersistentPath(timestamp);
                 return true;
@@ -59,6 +66,18 @@ public abstract class RemoteRequirement implements Requirement {
         Thread currentThread = Thread.currentThread();
         return BuildManager.getStartingTimeOfBuildManager(currentThread);
     }
+
+    /**
+     * Checks if the remote resource can be accessed.
+     * @return true if remote resourse can be accessed.
+     */
+    protected abstract boolean isRemoteResourceAccessible();
+
+    /**
+     * Checks if a version of the remote resource is available locally.
+     * @return true if a version of the remote resourse is locally available.
+     */
+    protected abstract boolean isLocalResourceAvailable();
 
     /**
      * Checks if the local state is consistent with the remote state.

--- a/pluto/test/build/pluto/test/dependency/MockRemoteRequirement.java
+++ b/pluto/test/build/pluto/test/dependency/MockRemoteRequirement.java
@@ -8,9 +8,11 @@ import build.pluto.dependency.RemoteRequirement;
 public class MockRemoteRequirement extends RemoteRequirement {
 
     private static final long serialVersionUID = 6725526956528720781L;
-    
+
     private boolean isConsistentWithRemote = false;
     private long ts = 0;
+    private boolean isRemoteAccessible = true;
+    private boolean isLocalAvailable = false;
 
     public MockRemoteRequirement(
             File persistentPath,
@@ -27,12 +29,30 @@ public class MockRemoteRequirement extends RemoteRequirement {
         this.ts = ts;
     }
 
+    public void setIsRemoteAccessible(boolean value) {
+        this.isRemoteAccessible = value;
+    }
+
+    public void setIsLocalAvailable(boolean value) {
+        this.isLocalAvailable = value;
+    }
+
+    @Override
+    protected boolean isRemoteResourceAccessible() {
+        return this.isRemoteAccessible;
+    }
+
+    @Override
+    protected boolean isLocalResourceAvailable() {
+        return this.isLocalAvailable;
+    }
+
     @Override
     protected boolean isConsistentWithRemote() {
         return this.isConsistentWithRemote;
     }
 
-    @Override 
+    @Override
     protected long getStartingTimestamp() {
         return this.ts;
     }

--- a/pluto/test/build/pluto/test/dependency/RemoteRequirementTest.java
+++ b/pluto/test/build/pluto/test/dependency/RemoteRequirementTest.java
@@ -136,6 +136,32 @@ public class RemoteRequirementTest {
         MockRemoteRequirement req = new MockRemoteRequirement(tsPath, -2L);
     }
 
+    @Test
+    public void checkRemoteNotAccessibleAndLocalVersionAvailable() {
+        MockRemoteRequirement req = new MockRemoteRequirement(tsPath, 5000L);
+        writeTSOnce(req, 6000L, true);
+        req.setIsRemoteAccessible(false);
+        req.setIsLocalAvailable(true);
+        boolean consistency = writeTSOnce(req, 13000L, false);
+        long contentOfFile = readTimestampFromFile(tsPath);
+
+        assertEquals(true, consistency);
+        assertEquals(6000L, contentOfFile);
+    }
+
+    @Test
+    public void checkRemoteNotAccessibleAndLocalVersionNotAvailable() {
+        MockRemoteRequirement req = new MockRemoteRequirement(tsPath, 5000L);
+        writeTSOnce(req, 6000L, true);
+        req.setIsRemoteAccessible(false);
+        req.setIsLocalAvailable(false);
+        boolean consistency = writeTSOnce(req, 13000L, false);
+        long contentOfFile = readTimestampFromFile(tsPath);
+
+        assertEquals(false, consistency);
+        assertEquals(6000L, contentOfFile);
+    }
+
     private boolean writeTSOnce(
             MockRemoteRequirement req,
             long ts,


### PR DESCRIPTION
…but local version is available
