### PR TITLE
Fix bug: File delete before InputStream is closed

### DIFF
--- a/src/build/pluto/PersistableEntity.java
+++ b/src/build/pluto/PersistableEntity.java
@@ -101,10 +101,8 @@ public abstract class PersistableEntity implements Serializable {
     if (!p.exists())
       return null;
       
-    ObjectInputStream in = null;
     E entity = null;
-    try {
-      in = new ObjectInputStream(new FileInputStream(p));
+    try(ObjectInputStream in = new ObjectInputStream(new FileInputStream(p))) {
       long id = in.readLong();
 
       entity = readFromMemoryCache(clazz, p);
@@ -132,9 +130,6 @@ public abstract class PersistableEntity implements Serializable {
       if (entity != null)
         entity.removeFromMemoryCache();
       return null;
-    } finally {
-      if (in != null)
-        in.close();
     }
   }
   


### PR DESCRIPTION
The catch clause would run `Files.delete` on file `p` before the finally clause would close the `InputStream in`. This is problematic on Windows, because opening the file locks it, therefore it cannot be deleted. Instead an exception is thrown and the whole build fails. 
This fix uses try-with-resources (introduced in Java 7), which closes the resource introduced between the brackets before running the catch clause.